### PR TITLE
Apply width, height, left, and top params to newStream

### DIFF
--- a/MultiStreamsMixer.js
+++ b/MultiStreamsMixer.js
@@ -467,6 +467,11 @@ function MultiStreamsMixer(arrayOfMediaStreams, elementClass) {
                 var video = getVideo(stream);
                 video.stream = stream;
                 videos.push(video);
+                
+                newStream.width = stream.width;
+                newStream.height = stream.height;
+                newStream.left = stream.left;
+                newStream.top = stream.top;
 
                 newStream.addTrack(stream.getTracks().filter(function(t) {
                     return t.kind === 'video';


### PR DESCRIPTION
The code from examples here don't work properly as the positional properties don't carry to `newStream` on creation.

```js
screenStream.fullcanvas = true;
screenStream.width = screen.width; // or 3840
screenStream.height = screen.height; // or 2160 

cameraStream.width = parseInt((20 / 100) * screenStream.width);
cameraStream.height = parseInt((20 / 100) * screenStream.height);
cameraStream.top = screenStream.height - cameraStream.height;
cameraStream.left = screenStream.width - cameraStream.width;
```
This pull ensures the positional properties of the given stram map to the `newStream`.