### PR TITLE
Update MultiStreamsMixer.js - About appendStreams function

### DIFF
--- a/MultiStreamsMixer.js
+++ b/MultiStreamsMixer.js
@@ -475,9 +475,14 @@ function MultiStreamsMixer(arrayOfMediaStreams, elementClass) {
 
             if (stream.getTracks().filter(function(t) {
                     return t.kind === 'audio';
-                }).length) {
+                }).length) {             
+                if (!Storage.AudioContextConstructor) {
+                    Storage.AudioContextConstructor = new Storage.AudioContext();
+                }
+                self.audioContext = Storage.AudioContextConstructor;
+                
                 var audioSource = self.audioContext.createMediaStreamSource(stream);
-                // self.audioDestination = self.audioContext.createMediaStreamDestination();
+                self.audioDestination = self.audioContext.createMediaStreamDestination();
                 audioSource.connect(self.audioDestination);
 
                 newStream.addTrack(self.audioDestination.stream.getTracks().filter(function(t) {


### PR DESCRIPTION
Hi forks,

I have an issue when try to init a new MultiStreamsMixer with an empty stream array at constructor.
Then I append some streams via "appendStreams" function with the config "audio: true" => error, because it uses "audioContext" but not init anywhere.

My PR solution is "init audioContext before use".

Steps to reproduce:

Init a new MultiStreamsMixer with an empty stream array .
Append streams(with audio config is true) via ".appendStreams".